### PR TITLE
Fix over allocating vertexes for OBJ models with multiple surfaces

### DIFF
--- a/libs/picomodel/pm_obj.c
+++ b/libs/picomodel/pm_obj.c
@@ -528,6 +528,7 @@ static picoModel_t *_obj_load( PM_PARAMS_LOAD ){
 			_obj_error_return( "Error allocating surface" ); } \
 		/* reset face index for surface */ \
 		curFace = 0; \
+		curVertex = 0; \
 		/* if we can, assign the previous shader to this surface */	\
 		if ( curSurface ) {	\
 			PicoSetSurfaceShader( newSurface, curSurface->shader ); } \


### PR DESCRIPTION
Loading Wavefront OBJ models in picomodel (used by radiant and q3map2)
did not reset the surface vertex index when starting a new surface. This
caused there to be unused vertexes, equal to the number of vertexes in
all previous surfaces, at the beginning of each surface. Exponential OBJ
vertex memory usage as number of surfaces increases. It did not affect
displaying or processing the surface faces.