### PR TITLE
Do not move symlinks when saving a map, overwrite target instead

### DIFF
--- a/radiant/preferences.cpp
+++ b/radiant/preferences.cpp
@@ -175,11 +175,8 @@ bool Preferences_Save( PreferenceDictionary& preferences, const char* filename )
 
 bool Preferences_Save_Safe( PreferenceDictionary& preferences, const char* filename ){
 	const auto tmpName = StringOutputStream()( filename, "TMP" );
-	return Preferences_Save( preferences, tmpName )
-	       && ( !file_exists( filename ) || file_remove( filename ) )
-	       && file_move( tmpName, filename );
+	return Preferences_Save( preferences, tmpName ) && file_move( tmpName, filename );
 }
-
 
 
 void LogConsole_importString( const char* string ){


### PR DESCRIPTION
If the user is editing a symlink to a target instead of a real file,
chances are high they want the symlink to stay in place.

Precondition:

  some.map -> /path/to/elsewhere.map

After save (before):

  some.bak -> /path/to/elsewhere.map
  some.map (real file)

After save (after):

  some.map -> /path/to/elsewhere.map

Closes #107.