### PR TITLE
Add CLions project folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 games
 install
 .vscode
+.idea


### PR DESCRIPTION
`.idea` folder is used by CLion to store project settings, similar to `.vscode` on Visual Studio Code.