### PR TITLE
add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+trim_trailing_whitespace = true
+indent_style = tab
+
+
+[*.{c,cc,cpp,h,hh,hpp}]
+indent_style = tab
+indent_size = 4
+
+[Makefile]
+indent_style = tab
+indent_size = 4
+trim_trailing_whitespace = false
+
+[*.md]
+indent_style = tab
+trim_trailing_whitespace = false


### PR DESCRIPTION
A ubiquitous cross IDE/Editor config format that is supported by most IDE/Editors out of the box these days.
See https://editorconfig.org/

Just a suggestion however, feel free to reject if you don't like it.
Thanks for the consideration!