### PR TITLE
fix q3map2 loadmodel pathsep crossplat

### DIFF
--- a/tools/quake3/q3map2/model.cpp
+++ b/tools/quake3/q3map2/model.cpp
@@ -295,7 +295,11 @@ static std::map<ModelNameFrame, AssModel> s_assModels;
    loads a picoModel and returns a pointer to the picoModel_t struct or NULL if not found
  */
 
-static AssModel *LoadModel( const char *name, int frame ){
+static AssModel *LoadModel( const char *rawName, int frame ){
+	// attempt to canonicalize name across platforms
+	auto nameStr = StringStream<64>( PathCleaned( rawName ) );
+	auto name    = nameStr.c_str();
+
 	/* dummy check */
 	if ( strEmptyOrNull( name ) ) {
 		return nullptr;


### PR DESCRIPTION
Radiant does some canonicalization on file paths, however 'q3map2' seems
to lack some.

For example on Linux loading a '.map' with a model path that involves
Windows path separators ('\\') will show and render them fine in
Radiant, however 'q3map2' will then fail to load them.

This commit applies some path canonicalization on q3map2's LoadModel to
remedy this specific issue.