### PR TITLE
fix q3map2 pathsep crossplat

### DIFF
--- a/tools/quake3/q3map2/map.cpp
+++ b/tools/quake3/q3map2/map.cpp
@@ -1683,6 +1683,24 @@ void LoadMapFile( const char *filename, bool onlyLights, bool noCollapseGroups )
 	int mapEntityNum = 0; /* track .map file entities numbering */
 	while ( ParseMapEntity( onlyLights, noCollapseGroups, mapEntityNum++ ) ){};
 
+	/* canonicalize paths cross plat */
+	for (auto &e : entities) {
+		for (epair_t &p : e.epairs) {
+			auto key     = p.key;
+			auto keyCstr = key.c_str();
+
+			if (
+				striEqual( keyCstr, "model" ) ||
+				striEqual( keyCstr, "_indexmap" ) ||
+				striEqual( keyCstr, "alphamap" ) ||
+				striEqual( keyCstr, "_shader" ) ||
+				striEqual( keyCstr, "shader" )
+				) {
+				p.value = StringStream<64>( PathCleaned( p.value.c_str() ) );
+			}
+		}
+	}
+
 	/* light loading */
 	if ( onlyLights ) {
 		/* emit some statistics */


### PR DESCRIPTION
Radiant does some canonicalization on file paths, however 'q3map2' seems to lack some.

For example on Linux loading a '.map' with a model path that involves Windows path separators ('\\') will show and render them fine in Radiant, however 'q3map2' will then fail to load them.

This commit adds a stage just right after parsing entities where known keys that are assumed to have paths as vals are cleaned.