### PR TITLE
log plugin load failures

### DIFF
--- a/radiant/server.cpp
+++ b/radiant/server.cpp
@@ -154,6 +154,10 @@ public:
 
 	DynamicLibrary( const char* filename ){
 		m_library = dlopen( filename, RTLD_NOW );
+		if ( failed() ) {
+			globalErrorStream() << "LoadLibrary failed: '" << filename << "'\n";
+			globalErrorStream() << "Module dlopen(3) Error: " << dlerror() << '\n';
+		}
 	}
 	~DynamicLibrary(){
 		if ( !failed() ) {


### PR DESCRIPTION
When plugins fail loading they currently are silently ignored - this commit adds stderr logging output to diagnose what went wrong.