### PR TITLE
add .py / .json rules to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,14 @@ trim_trailing_whitespace = true
 indent_style = tab
 
 
+[*.py]
+indent_style = space
+indent_size = 2
+
+[*.{json,yml,yaml}]
+indent_style = space
+indent_size = 2
+
 [*.{c,cc,cpp,h,hh,hpp}]
 indent_style = tab
 indent_size = 4


### PR DESCRIPTION
These were just missing for existing .py files.
Added '.json/.yml/.yaml' just in case.