### PR TITLE
Disable the wayland backend on Linux by default

### DIFF
--- a/radiant/main.cpp
+++ b/radiant/main.cpp
@@ -401,6 +401,13 @@ void remove_local_pid(){
 
 
 int main( int argc, char* argv[] ){
+#ifdef __linux__
+	// Mouse pointer warping functions do not work with the Wayland backend.
+	// Forcing the backend to X11 will let us run using XWayland
+	// which does provide emulation of this functionality.
+	setenv("QT_QPA_PLATFORM", "xcb", 0);
+#endif
+
 	crt_init();
 
 	streams_init();


### PR DESCRIPTION
The viewports are currently not usable on Wayland:
`QT WRN qt.qpa.wayland: Setting cursor position is not possible on wayland`

With this change, the X11 (Xwayland) backend is always used instead, no need to manually set the `QT_QPA_PLATFORM=xcb` environment variable before starting NRC.

It kinda fixes #126 

Sorry if this is not the right place to put this code, I'm not familiar with C++ :>

The same thing (with a GTK environment variable) exists in NetRadiant and DarkRadiant:
https://gitlab.com/xonotic/netradiant/-/blob/master/radiant/main.cpp?ref_type=heads#L540
https://github.com/codereader/DarkRadiant/commit/cbda48384c3b2ced6412812ecd1a25440541c89e