### PR TITLE
prevent logging q3map2's output twice on linux with build monitoring

### DIFF
--- a/libs/commandlib.cpp
+++ b/libs/commandlib.cpp
@@ -33,12 +33,15 @@
 
 #include <cstdlib>
 #include <unistd.h>
+#include <fcntl.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+
 
 bool Q_Exec( const char *cmd, char *cmdline, const char *, bool, bool waitfor ){
 	char fullcmd[2048];
 	char *pCmd;
+
 	pid_t pid;
 #ifdef _DEBUG
 	printf( "Q_Exec damnit\n" );
@@ -54,6 +57,17 @@ bool Q_Exec( const char *cmd, char *cmdline, const char *, bool, bool waitfor ){
 		return true;
 		break;
 	case 0:
+		// XXX : if we run q3map2 with '-connect' - redirect stdout and stderr
+		//		 to /dev/null - aka build monitoring - as it's already going to
+		//		 be written to stdout via 'radiant/console.cpp → Sys_print
+		if ( cmdline != NULL && ( strstr( cmdline, "q3map2" ) != NULL ) && ( strstr( cmdline, "-connect" ) != NULL ) ) {
+			int devNullFd = open( "/dev/null", 0 );
+			if ( devNullFd != -1 ) {
+				dup2( devNullFd, 1 );
+				dup2( devNullFd, 2 );
+			}
+		}
+
 		// always concat the command on linux
 		if ( cmd ) {
 			strcpy( fullcmd, cmd );


### PR DESCRIPTION
In the case of using q3map2 with 'build monitoring', the output of q3map2 was being written twice, once for the logs received through the 'watchbsp' net connection and once as the fork/subprocess that actually runs q3map2 was using the same stdout file descriptor as netradiant-custom itself.

In order to prevent this, we redirect stdout/stderr to /dev/null in case we use q3map2 with build monitoring for the subprocess and rely on the received logs, which also get written to netradiant-custom's QT console.