### PR TITLE
assimp: Fix compilation errors

### DIFF
--- a/libs/assimp/code/AssetLib/MMD/MMDPmxParser.h
+++ b/libs/assimp/code/AssetLib/MMD/MMDPmxParser.h
@@ -47,6 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <fstream>
 #include <memory>
 #include "MMDCpp14.h"
+#include <stdint.h> 
 
 namespace pmx
 {


### PR DESCRIPTION
Fixes:

	In file included from libs/assimp/code/AssetLib/MMD/MMDPmxParser.cpp:43:
	libs/assimp/code/AssetLib/MMD/MMDPmxParser.h:67:17: error: ‘uint8_t’ does not name a type
	   67 |                 uint8_t encoding;
	      |                 ^~~~~~~

	...