### PR TITLE
fix vertex lights being broken on lightmapped surfaces for styled lights

### DIFF
--- a/tools/quake3/q3map2/light_ydnar.cpp
+++ b/tools/quake3/q3map2/light_ydnar.cpp
@@ -3230,8 +3230,8 @@ void IlluminateVertexes( int num ){
 			}
 
 			/* get luxel coords */
-			x = std::clamp( int( verts[ i ].lightmap[ lightmapNum ][ 0 ] ), 0, lm->sw - 1 );
-			y = std::clamp( int( verts[ i ].lightmap[ lightmapNum ][ 1 ] ), 0, lm->sh - 1 );
+			x = std::clamp( int( verts[ i ].lightmap[ 0 ][ 0 ] ), 0, lm->sw - 1 );
+			y = std::clamp( int( verts[ i ].lightmap[ 0 ][ 1 ] ), 0, lm->sh - 1 );
 
 			/* get vertex luxels */
 			Vector3& vertLuxel = getVertexLuxel( lightmapNum, ds->firstVert + i );


### PR DESCRIPTION
Explanation:
Comes from that whole duality of lightmap coordinates for bsp and internal use. Internal always uses index (lightmapnum) 0 for the raw lightmap. The concrete final lightmap coordinates are only calculated and stored when saving the bsp and kept separate. For internal use, all other indices are never inited. Vertex light code tried to use the uninited raw lightmap coordinates with lightmapNum > 0, so just got either zeros or garbage for them for anything except the base lightmap/style 0.