### PR TITLE
Fix bounce lighting for styled lights

### DIFF
--- a/tools/quake3/q3map2/light_bounce.cpp
+++ b/tools/quake3/q3map2/light_bounce.cpp
@@ -283,7 +283,7 @@ static void RadSample( int lightmapNum, bspDrawSurface_t *ds, rawLightmap_t *lm,
 						for ( l = 0; l < 3; l++ )
 						{
 							st += rv[ l ]->st * blend[ l ];
-							lightmap += rv[ l ]->lightmap[ lightmapNum ] * blend[ l ];
+							lightmap += rv[ l ]->lightmap[ 0 ] * blend[ l ];
 							alphaI += rv[ l ]->color[ lightmapNum ].alpha() * blend[ l ];
 						}
 


### PR DESCRIPTION
Similar bug to https://github.com/Garux/netradiant-custom/pull/238 

Bounce lighting for styled lights produced inexplicable artifacts and light in areas where it shouldn't be.

Reason: RadSample is calculating the lightmap texture coordinates to be sampled for the radiance light value based on the coordinates stored in the vertices. Those vertices are sourced from yDrawVerts, which is the internal vertex storage referencing the raw lightmap texture coordinates, not the final bsp lightmap coordinates. Therefore only lightmap[0] exists, and accessing lightmap[lightmapNum] yields random nonsense.