### PR TITLE
Add 'hide unselected'

### DIFF
--- a/radiant/filterbar.cpp
+++ b/radiant/filterbar.cpp
@@ -197,4 +197,7 @@ void create_filter_toolbar( QToolBar *toolbar ){
 
 	button = toolbar_append_toggle_button( toolbar, "Hide Selected\nRightClick: Show Hidden", "f-hide.png", "HideSelected" );
 	handler->m_actions.emplace( button, new CommonFunc_command( "ShowHidden" ) );
+
+	button = toolbar_append_toggle_button( toolbar, "Hide Unselected\nRightClick: Show Hidden", "f-hide.png", "HideUnselected" );
+	handler->m_actions.emplace( button, new CommonFunc_command( "ShowHidden" ) );
 }

--- a/radiant/mainframe.cpp
+++ b/radiant/mainframe.cpp
@@ -1035,6 +1035,7 @@ void create_view_menu( QMenuBar *menubar, MainFrame::EViewStyle style ){
 	menu->addSeparator();
 	{
 		create_check_menu_item_with_mnemonic( menu, "Hide Selected", "HideSelected" );
+		create_check_menu_item_with_mnemonic( menu, "Hide Unselected", "HideUnselected" );
 		create_menu_item_with_mnemonic( menu, "Show Hidden", "ShowHidden" );
 	}
 	menu->addSeparator();

--- a/radiant/select.cpp
+++ b/radiant/select.cpp
@@ -988,6 +988,11 @@ void HideSelected(){
 	g_hidden_item.update();
 }
 
+void HideUnselected(){
+	Scene_Invert_Selection( GlobalSceneGraph() );
+	HideSelected();
+	Scene_Invert_Selection( GlobalSceneGraph() );
+}
 
 class HideAllWalker : public scene::Graph::Walker
 {
@@ -1840,6 +1845,7 @@ void SelectConnectedEntities(){
 void Select_registerCommands(){
 	GlobalCommands_insert( "ShowHidden", makeCallbackF( Select_ShowAllHidden ), QKeySequence( "Shift+H" ) );
 	GlobalToggles_insert( "HideSelected", makeCallbackF( HideSelected ), ToggleItem::AddCallbackCaller( g_hidden_item ), QKeySequence( "H" ) );
+	GlobalToggles_insert( "HideUnselected", makeCallbackF( HideUnselected ), ToggleItem::AddCallbackCaller( g_hidden_item ), QKeySequence( "Alt+H" ) );
 
 	GlobalCommands_insert( "MirrorSelectionX", makeCallbackF( Selection_Flipx ) );
 	GlobalCommands_insert( "RotateSelectionX", makeCallbackF( Selection_Rotatex ) );


### PR DESCRIPTION
> -Added a command to hide currently unselected level components.

I'll be clear that C++ programming is entirely outside of my wheelhouse, I'm just a tenacious person with a high pain tolerance. Professionally I'm a level designer with 15ish years of experience, but do a lot of gameplay scripting / technical level design.

I've used Radiant professionally for a long time, and I grew accustomed to having a command that would let me isolate my selection and hide everything else. I've been using NetRadiant for local gamedev work and I hadn't had any luck finding a command in the interface to hide unselected or isolate the current selection, and figured, "how hard could it be to add?"

A better programmer would've undoubtedly done this faster (or probably been able to point out where this already actually existed in the code). I figured I'd give it a shot and put in a pull request for it, if not to at least get real programmer's eyes on what I did, and figure out the correct implementation.

All I'm doing is just inverting your selection, running hide selected, and inverting your selection again, so the only level components left in the scene are the ones you had selected in the first place. My first thought was to invert the bool check in HideSelected's scene walker, but that didn't pan out. I'm not very familiar with traditional coding patterns, so I wasn't able to work that out correctly, and I had a hunch that just duplicating the scene walker and inverting the bool isn't a good solution anyway (even if it did work) because of the amount of duplicated code.

I compiled it, tested the command, seemed to do what I wanted it to do.

Couple potential issues:
-Icons reused from Hide Selected. I thought about modifying it, but figured that can come later during the pull request process.
-The button on the filterbar toggles when Hide Selected is checked, and Hide Selected toggles when Hide Unselected is checked. Not sure if that counts as a real issue, but figured I'd mention it in case anyone has thoughts on it.
-I was unable to test the default shortcut, in fact none of the 'alt + key' shortcuts worked. I'm assuming thats a me problem. But again figured I'd mention it. Changing the shortcut to a different key correctly hides unselected level components.
-Command probably could use validation in the form of not running if you don't have anything selected.