### PR TITLE
Write `noCompress` or `noTC` to generated nomips shaders, when available

### DIFF
--- a/tools/quake3/q3map2/games.cpp
+++ b/tools/quake3/q3map2/games.cpp
@@ -124,6 +124,7 @@ struct game_default : game_t
 	false,              /* cod-style lump len/ofs order */
 	LoadIBSPFile,       /* bsp load function */
 	WriteIBSPFile,      /* bsp write function */
+	"",                 /* if not null, shader parameter for disabling texture compression */
 
 	{
 		/* name             contentFlags                contentFlagsClear           surfaceFlags                surfaceFlagsClear           compileFlags                compileFlagsClear */
@@ -356,6 +357,7 @@ struct game_wolf : game_default
 		magic = "wolf";
 		wolfLight = true;
 		bspVersion = 47;
+		noCompressTextureKeyword = "nocompress";
 		surfaceParms.insert( surfaceParms.end(), {
 			/* game */
 			{ "slag",           Q_CONT_SLIME,               Q_CONT_SOLID,               0,                          0,                          C_LIQUID | C_TRANSLUCENT,   C_SOLID },
@@ -411,6 +413,7 @@ struct game_wolfet : game_wolf
 		maxLMSurfaceVerts = 1024;
 		maxSurfaceVerts = 1024;
 		maxSurfaceIndexes = 6144;
+		noCompressTextureKeyword = ""; // unnecessary, as external lightmaps are natively supported
 		surfaceParms.insert( surfaceParms.end(), {
 		{ "landmine",       0,                          0,                          W_SURF_LANDMINE,            0,                          0,                          0 },
 		{ "splash",         0,                          0,                          W_SURF_SPLASH,              0,                          0,                          0 },
@@ -556,6 +559,7 @@ struct game_qfusion : game_default
 		bspVersion = 1;
 		load = LoadRBSPFile;
 		write = WriteRBSPFile;
+		noCompressTextureKeyword = "nocompress";
 	}
 };
 
@@ -785,6 +789,7 @@ struct game_sof2 : game_t
 	false,                  /* cod-style lump len/ofs order */
 	LoadRBSPFile,           /* bsp load function */
 	WriteRBSPFile,          /* bsp write function */
+	"noTC",                 /* if not null, shader parameter for disabling texture compression */
 
 	{
 		/* name             contentFlags                contentFlagsClear           surfaceFlags                surfaceFlagsClear           compileFlags                compileFlagsClear */

--- a/tools/quake3/q3map2/games.h
+++ b/tools/quake3/q3map2/games.h
@@ -106,6 +106,7 @@ struct game_t
 	bool lumpSwap;                                      /* cod-style len/ofs order */
 	typedef void ( *bspFunc )( const char * );
 	bspFunc load, write;                                /* load/write function pointers */
+	const char          *noCompressTextureKeyword;      /* shader parameter which disables texture compression for uploaded textures (used for external hack lightmaps); null string means no such parameter exists */
 	std::vector<surfaceParm_t> surfaceParms;            /* surfaceparm array */
 	int brushBevelsSurfaceFlagsMask;                    /* apply only these surfaceflags to bevels to reduce extra bsp shaders amount; applying them to get correct physics at walkable brush edges and vertices */
 };

--- a/tools/quake3/q3map2/light.cpp
+++ b/tools/quake3/q3map2/light.cpp
@@ -1836,9 +1836,20 @@ static void WriteBSPFileAfterLight( const char *bspFileName ){
 				fprintf( file, "\n// Shaders to force nomipmaps flag on external lightmap images:\n\n" );
 
 				/* devise les shaders: max 8 stages, max 8 maps in animmap */
+				bool hasNoCompressParm = false;
+				if ((g_game->noCompressTextureKeyword) != "")
+				{
+					/* avoid excess string comparisons later */
+					hasNoCompressParm = true;
+				}
 				size_t shaderId = 0;
 				for( auto it = lmIds.cbegin(); it != lmIds.cend(); ){
 					fprintf( file, "%s\n{\n\tnomipmaps\n", String64( lmPathStart, "nomipmaps", shaderId++ ).c_str() );
+					if (hasNoCompressParm)
+					{
+						/* don't compress hack lightmaps, if possible */
+						fprintf(file, "\t%s\n", (g_game->noCompressTextureKeyword));
+					}
 					for( size_t i = 0; i < 8 && it != lmIds.cend(); ++i ){
 						fprintf( file, "\t{\n\t\tanimmap .0042" );
 						for( size_t j = 0; j < 8 && it != lmIds.cend(); ++j, ++it ){


### PR DESCRIPTION
Prevents undesirable DXTn/BCn/S3TC artefacts from appearing on lightmaps when r_ext_compressed_textures is enabled (which often is enabled by default ). 
An additional field is added to `game_t` to control this.

Affects the following games:
* *Return to Castle Wolfenstein* (`wolf`)
* *Solider of Fortune II* (`sof2`)
* *Jedi Outcast* (`jk2`)
* *Jedi Academy* (`ja`)
* *QFusion* (`qfusion`)

I disabled this behavior for *Wolfenstein: Enemy Territory* (`et`) and *Urban Terror in Enemy Territory* (`etut`), because their native support for external lightmaps means they shouldn't need this (in theory, they shouldn't be writing these shaders at all, but idk if that's the case).

PR is flagged as draft because I haven't tested to make sure it works as intended yet.